### PR TITLE
Python3 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,9 +12,9 @@ Requirements
 ------------
 
 * pylibmc
-* Django 1.3+.
+* Django 1.5+.
 
-It was written and tested on Python 2.7.
+It was written and tested on Python 2.7 and 3.4.
 
 Installation
 ------------

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,6 +1,15 @@
-from django.conf import global_settings
-from mock import patch, Mock
+from django.conf import global_settings, settings
 from nose.tools import eq_, raises
+import sys
+if sys.version < '3':
+    from mock import patch, Mock
+else:
+    from unittest.mock import patch, Mock
+
+
+# Initialize django 1.7
+settings.configure()
+global_settings.configured = True
 
 
 @patch('django.conf.settings', global_settings)

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,16 +1,21 @@
-from mock import patch, call, MagicMock
 from django_elasticache.cluster_utils import (
     get_cluster_info, WrongProtocolData)
 from nose.tools import eq_, raises
+import sys
+if sys.version < '3':
+    from mock import patch, call, MagicMock
+else:
+    from unittest.mock import patch, call, MagicMock
+
 
 TEST_PROTOCOL_1 = [
-    'VERSION 1.4.14',
-    'CONFIG cluster 0 138\r\n1\nhost|ip|port host||port\n\r\nEND\r\n',
+    b'VERSION 1.4.14',
+    b'CONFIG cluster 0 138\r\n1\nhost|ip|port host||port\n\r\nEND\r\n',
 ]
 
 TEST_PROTOCOL_2 = [
-    'VERSION 1.4.13',
-    'CONFIG cluster 0 138\r\n1\nhost|ip|port host||port\n\r\nEND\r\n',
+    b'VERSION 1.4.13',
+    b'CONFIG cluster 0 138\r\n1\nhost|ip|port host||port\n\r\nEND\r\n',
 ]
 
 
@@ -35,8 +40,8 @@ def test_last_versions(Telnet):
     client.read_until.side_effect = TEST_PROTOCOL_1
     get_cluster_info('', 0)
     client.write.assert_has_calls([
-        call('version\n'),
-        call('config get cluster\n'),
+        call(b'version\n'),
+        call(b'config get cluster\n'),
     ])
 
 
@@ -46,6 +51,6 @@ def test_prev_versions(Telnet):
     client.read_until.side_effect = TEST_PROTOCOL_2
     get_cluster_info('', 0)
     client.write.assert_has_calls([
-        call('version\n'),
-        call('get AmazonElastiCache:cluster\n'),
+        call(b'version\n'),
+        call(b'get AmazonElastiCache:cluster\n'),
     ])


### PR DESCRIPTION
Add support for Python3 by being explicit about byte strings. Also, initialized settings in the django tests (which is required in at least django 1.7) -- based on @aroxby's fork. This uses a feature of django 1.5+ to convert back to strings as necessary, so this breaks support < 1.5.

Tests pass with Python 3.4 + django 1.7, Python 2.7 + django 1.7, Python 2.7 + django 1.6, Python 2.7 + django 1.5.

Manually tested set/get with Python 3.4 + django 1.7 (production environment).
