### PR TITLE
Resolve issue #13 by making cluster_utils.get_cluster_info less brittle.

### DIFF
--- a/django_elasticache/cluster_utils.py
+++ b/django_elasticache/cluster_utils.py
@@ -32,7 +32,7 @@ def get_cluster_info(host, port):
     client.write(b'version\n')
     res = client.read_until(b'\r\n').strip()
     version_list = res.split(b' ')
-    if len(version_list) != 2 or version_list[0] != b'VERSION':
+    if not len(version_list) in [2, 3] or version_list[0] != b'VERSION':
         raise WrongProtocolData('version', res)
     version = version_list[1]
     if StrictVersion(smart_text(version)) >= StrictVersion('1.4.14'):


### PR DESCRIPTION
This PR is in response to Issue #13, which I submitted earlier today. I fixed the issue by increasing the number of space-delimited "parts" of the version string to be either two or three. This is about as narrow of a fix as I could come up with.

I have also written a test case to replicate the issue; it's included in the commit.