### PR TITLE
Add support for when cluster endpoint is not available

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,10 +36,13 @@ Your cache backend should look something like this::
         'default': {
             'BACKEND': 'django_elasticache.memcached.ElastiCache',
             'LOCATION': 'cache-c.draaaf.cfg.use1.cache.amazonaws.com:11211',
+            'OPTIONS' {
+                'IGNORE_CLUSTER_ERRORS': [True,False],
+            },
         }
     }
 
-By the first call to cache it connects to cluster (using LOCATION param),
+By the first call to cache it connects to cluster (using ``LOCATION`` param),
 gets list of all nodes and setup pylibmc client using full
 list of nodes. As result your cache will work with all nodes in cluster and
 automatically detect new nodes in cluster. List of nodes are stored in class-level
@@ -47,6 +50,10 @@ cached, so any changes in cluster take affect only after restart of working proc
 But if you're using gunicorn or mod_wsgi you usually have max_request settings which
 restart process after some count of processed requests, so auto discovery will work
 fine.
+
+The ``IGNORE_CLUSTER_ERRORS`` option is useful when ``LOCATION`` doesn't have support
+for ``config get cluster``. When set to ``True``, and ``config get cluster`` fails,
+it returns a list of a single node with the same endpoint supplied to ``LOCATION``.
 
 Django-elasticache changes default pylibmc params to increase performance.
 

--- a/django_elasticache/cluster_utils.py
+++ b/django_elasticache/cluster_utils.py
@@ -17,7 +17,7 @@ class WrongProtocolData(ValueError):
             'Unexpected response {} for command {}'.format(response, cmd))
 
 
-def get_cluster_info(host, port, ignore_cluster_errors=False, timeout=3):
+def get_cluster_info(host, port, ignore_cluster_errors=False):
     """
     return dict with info about nodes in cluster and current version
     {
@@ -30,7 +30,7 @@ def get_cluster_info(host, port, ignore_cluster_errors=False, timeout=3):
     """
     client = Telnet(host, int(port))
     client.write(b'version\n')
-    res = client.read_until(b'\r\n', timeout).strip()
+    res = client.read_until(b'\r\n').strip()
     version_list = res.split(b' ')
     if len(version_list) not in [2, 3] or version_list[0] != b'VERSION':
         raise WrongProtocolData('version', res)
@@ -43,7 +43,7 @@ def get_cluster_info(host, port, ignore_cluster_errors=False, timeout=3):
     regex_index, match_object, res = client.expect([
         re.compile(b'\n\r\nEND\r\n'),
         re.compile(b'ERROR\r\n')
-    ], timeout)
+    ])
     client.close()
 
     if res == b'ERROR\r\n' and ignore_cluster_errors:

--- a/django_elasticache/cluster_utils.py
+++ b/django_elasticache/cluster_utils.py
@@ -40,10 +40,13 @@ def get_cluster_info(host, port, timeout=3):
     else:
         cmd = b'get AmazonElastiCache:cluster\n'
     client.write(cmd)
-    res = client.read_until(b'\n\r\nEND\r\n', timeout)
+    regex_index, match_object, res = client.expect([
+        re.compile(b'\n\r\nEND\r\n'),
+        re.compile(b'ERROR\r\n')
+    ], timeout)
     client.close()
 
-    if res == 'ERROR\r\n':
+    if res == b'ERROR\r\n':
         return {
             'version': version,
             'nodes': [

--- a/django_elasticache/cluster_utils.py
+++ b/django_elasticache/cluster_utils.py
@@ -17,7 +17,7 @@ class WrongProtocolData(ValueError):
             'Unexpected response {} for command {}'.format(response, cmd))
 
 
-def get_cluster_info(host, port, timeout=3):
+def get_cluster_info(host, port, ignore_cluster_errors=False, timeout=3):
     """
     return dict with info about nodes in cluster and current version
     {
@@ -46,7 +46,7 @@ def get_cluster_info(host, port, timeout=3):
     ], timeout)
     client.close()
 
-    if res == b'ERROR\r\n':
+    if res == b'ERROR\r\n' and ignore_cluster_errors:
         return {
             'version': version,
             'nodes': [

--- a/django_elasticache/memcached.py
+++ b/django_elasticache/memcached.py
@@ -38,6 +38,9 @@ class ElastiCache(PyLibMCCache):
             raise InvalidCacheBackendError(
                 'Server configuration should be in format IP:port')
 
+        self._ignore_cluster_errors = self._options.get(
+            'IGNORE_CLUSTER_ERRORS', False)
+
     def update_params(self, params):
         """
         update connection params to maximize performance
@@ -51,7 +54,8 @@ class ElastiCache(PyLibMCCache):
             # set special 'behaviors' pylibmc attributes
             params['OPTIONS'] = {
                 'tcp_nodelay': True,
-                'ketama': True
+                'ketama': True,
+                'IGNORE_CLUSTER_ERRORS': False,
             }
 
     def clear_cluster_nodes_cache(self):
@@ -67,7 +71,8 @@ class ElastiCache(PyLibMCCache):
             server, port = self._servers[0].split(':')
             try:
                 self._cluster_nodes_cache = (
-                    get_cluster_info(server, port)['nodes'])
+                    get_cluster_info(server, port,
+                                     self._ignore_cluster_errors)['nodes'])
             except (socket.gaierror, socket.timeout) as err:
                 raise Exception('Cannot connect to cluster {} ({})'.format(
                     self._servers[0], err

--- a/django_elasticache/memcached.py
+++ b/django_elasticache/memcached.py
@@ -54,8 +54,7 @@ class ElastiCache(PyLibMCCache):
             # set special 'behaviors' pylibmc attributes
             params['OPTIONS'] = {
                 'tcp_nodelay': True,
-                'ketama': True,
-                'IGNORE_CLUSTER_ERRORS': False,
+                'ketama': True
             }
 
     def clear_cluster_nodes_cache(self):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -20,7 +20,6 @@ def test_patch_params():
     eq_(params['BINARY'], True)
     eq_(params['OPTIONS']['tcp_nodelay'], True)
     eq_(params['OPTIONS']['ketama'], True)
-    eq_(params['OPTIONS']['IGNORE_CLUSTER_ERRORS'], False)
 
 
 @raises(Exception)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -20,6 +20,7 @@ def test_patch_params():
     eq_(params['BINARY'], True)
     eq_(params['OPTIONS']['tcp_nodelay'], True)
     eq_(params['OPTIONS']['ketama'], True)
+    eq_(params['OPTIONS']['IGNORE_CLUSTER_ERRORS'], False)
 
 
 @raises(Exception)
@@ -47,7 +48,7 @@ def test_split_servers(get_cluster_info):
     }
     backend._lib.Client = Mock()
     assert backend._cache
-    get_cluster_info.assert_called_once_with('h', '0')
+    get_cluster_info.assert_called_once_with('h', '0', False)
     backend._lib.Client.assert_called_once_with(servers)
 
 
@@ -70,7 +71,7 @@ def test_node_info_cache(get_cluster_info):
     eq_(backend._cache.get.call_count, 2)
     eq_(backend._cache.set.call_count, 2)
 
-    get_cluster_info.assert_called_once_with('h', '0')
+    get_cluster_info.assert_called_once_with('h', '0', False)
 
 
 @patch('django.conf.settings', global_settings)

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -99,14 +99,27 @@ def test_ubuntu_protocol(Telnet):
 
 
 @patch('django_elasticache.cluster_utils.Telnet')
-def test_no_configuration_protocol_support(Telnet):
+def test_no_configuration_protocol_support_with_errors_ignored(Telnet):
     client = Telnet.return_value
     client.read_until.side_effect = TEST_PROTOCOL_4_READ_UNTIL
     client.expect.side_effect = TEST_PROTOCOL_4_EXPECT
-    info = get_cluster_info('test', 0)
+    info = get_cluster_info('test', 0, ignore_cluster_errors=True)
     client.write.assert_has_calls([
         call(b'version\n'),
         call(b'config get cluster\n'),
     ])
     eq_(info['version'], '1.4.34')
     eq_(info['nodes'], ['test:0'])
+
+
+@raises(WrongProtocolData)
+@patch('django_elasticache.cluster_utils.Telnet')
+def test_no_configuration_protocol_support_with_errors(Telnet):
+    client = Telnet.return_value
+    client.read_until.side_effect = TEST_PROTOCOL_4_READ_UNTIL
+    client.expect.side_effect = TEST_PROTOCOL_4_EXPECT
+    get_cluster_info('test', 0, ignore_cluster_errors=False)
+    client.write.assert_has_calls([
+        call(b'version\n'),
+        call(b'config get cluster\n'),
+    ])


### PR DESCRIPTION
Modify `get_cluster_info` to include a timeout (defaults to 3 seconds) and match against the success (`END`) and failure case (`ERROR`) in the same call. From there, gracefully degrade (only if the `IGNORE_CLUSTER_ERRORS` option is `True`) when the ElastiCache cluster configuration endpoint isn't available by returning the provided `host` and `port` in the `nodes` list.

Also, add two additional tests to the protocol test suite to cover the additional functionality.

Fixes #16 

---

**Testing**

```bash
root@22a790647170:/usr/src/app# python setup.py nosetests
running nosetests
running egg_info
writing requirements to django_elasticache.egg-info/requires.txt
writing django_elasticache.egg-info/PKG-INFO
writing top-level names to django_elasticache.egg-info/top_level.txt
writing dependency_links to django_elasticache.egg-info/dependency_links.txt
reading manifest file 'django_elasticache.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'django_elasticache.egg-info/SOURCES.txt'
............
----------------------------------------------------------------------
Ran 13 tests in 0.159s

OK
```

These tests were executed within a Python 2.7 Docker container with all of the necessary dependencies. Let me know if you'd like [that setup](https://github.com/gusdan/django-elasticache/compare/master...hectcastro:feature/hmc/docker-support) in a separate PR.