### PR TITLE
Move pylibmc behaviors into sub behaviors key

### DIFF
--- a/django_elasticache/memcached.py
+++ b/django_elasticache/memcached.py
@@ -94,7 +94,10 @@ class ElastiCache(PyLibMCCache):
 
         client = self._lib.Client(self.get_cluster_nodes())
         if self._options:
-            client.behaviors = self._options
+            # In Django 1.11, all behaviors are shifted into a behaviors dict
+            # Attempt to get from there, and fall back to old behavior if the behaviors
+            # key does not exist
+            client.behaviors = self._options.get('behaviors', self._options)
 
         container._client = client
 


### PR DESCRIPTION
Related to https://github.com/gusdan/django-elasticache/issues/18.

@gusdan Any thoughts on this change?  

Also I would be willing to up the base supported version of django if you were interested given their deprecation/support schedule.