### PR TITLE
Make format calls python2.6 compatible

### DIFF
--- a/django_elasticache/cluster_utils.py
+++ b/django_elasticache/cluster_utils.py
@@ -14,7 +14,7 @@ class WrongProtocolData(ValueError):
     """
     def __init__(self, cmd, response):
         super(WrongProtocolData, self).__init__(
-            'Unexpected response {} for command {}'.format(response, cmd))
+            'Unexpected response {0} for command {1}'.format(response, cmd))
 
 
 def get_cluster_info(host, port, ignore_cluster_errors=False):
@@ -50,7 +50,7 @@ def get_cluster_info(host, port, ignore_cluster_errors=False):
         return {
             'version': version,
             'nodes': [
-                '{}:{}'.format(smart_text(host),
+                '{0}:{1}'.format(smart_text(host),
                                smart_text(port))
             ]
         }
@@ -67,7 +67,7 @@ def get_cluster_info(host, port, ignore_cluster_errors=False):
     try:
         for node in ls[2].split(b' '):
             host, ip, port = node.split(b'|')
-            nodes.append('{}:{}'.format(smart_text(ip or host),
+            nodes.append('{0}:{1}'.format(smart_text(ip or host),
                                         smart_text(port)))
     except ValueError:
         raise WrongProtocolData(cmd, res)

--- a/django_elasticache/memcached.py
+++ b/django_elasticache/memcached.py
@@ -73,7 +73,7 @@ class ElastiCache(PyLibMCCache):
                     get_cluster_info(server, port,
                                      self._ignore_cluster_errors)['nodes'])
             except (socket.gaierror, socket.timeout) as err:
-                raise Exception('Cannot connect to cluster {} ({})'.format(
+                raise Exception('Cannot connect to cluster {0} ({1})'.format(
                     self._servers[0], err
                 ))
         return self._cluster_nodes_cache


### PR DESCRIPTION
Automatic numbering of {} clauses inside the format call were only
introduced into python2.7.

This change allows for running on python2.6 for gradual modernization
projects.