### PR TITLE
Also catch errors of type pylibmc.Error

### DIFF
--- a/django_elasticache/memcached.py
+++ b/django_elasticache/memcached.py
@@ -16,7 +16,7 @@ def invalidate_cache_after_error(f):
     def wrapper(self, *args, **kwds):
         try:
             return f(self, *args, **kwds)
-        except Exception:
+        except (Exception, self._lib.Error):
             self.clear_cluster_nodes_cache()
             raise
     return wrapper


### PR DESCRIPTION
Some of the lower level exceptions in pylibmc do not derive from Exception but rather pylibmc.Error, and thus (for example) the cluster nodes cache was not being invalidated after `CONNECTION FAILURE`.

This change attempts to also catch those errors.