### PR TITLE
BugFix: "Transport endpoint is not connected"

### DIFF
--- a/django_elasticache/cluster_utils.py
+++ b/django_elasticache/cluster_utils.py
@@ -2,7 +2,7 @@
 utils for discovery cluster
 """
 from distutils.version import StrictVersion
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 import re
 from telnetlib import Telnet
 
@@ -35,7 +35,7 @@ def get_cluster_info(host, port, ignore_cluster_errors=False):
     if len(version_list) not in [2, 3] or version_list[0] != b'VERSION':
         raise WrongProtocolData('version', res)
     version = version_list[1]
-    if StrictVersion(smart_text(version)) >= StrictVersion('1.4.14'):
+    if StrictVersion(smart_str(version)) >= StrictVersion('1.4.14'):
         cmd = b'config get cluster\n'
     else:
         cmd = b'get AmazonElastiCache:cluster\n'
@@ -50,8 +50,8 @@ def get_cluster_info(host, port, ignore_cluster_errors=False):
         return {
             'version': version,
             'nodes': [
-                '{0}:{1}'.format(smart_text(host),
-                               smart_text(port))
+                '{0}:{1}'.format(smart_str(host),
+                               smart_str(port))
             ]
         }
 
@@ -67,8 +67,8 @@ def get_cluster_info(host, port, ignore_cluster_errors=False):
     try:
         for node in ls[2].split(b' '):
             host, ip, port = node.split(b'|')
-            nodes.append('{0}:{1}'.format(smart_text(ip or host),
-                                        smart_text(port)))
+            nodes.append('{0}:{1}'.format(smart_str(ip or host),
+                                        smart_str(port)))
     except ValueError:
         raise WrongProtocolData(cmd, res)
     return {

--- a/django_elasticache/memcached.py
+++ b/django_elasticache/memcached.py
@@ -5,6 +5,7 @@ import socket
 from functools import wraps
 from django.core.cache import InvalidCacheBackendError
 from django.core.cache.backends.memcached import PyLibMCCache
+from threading import local
 from .cluster_utils import get_cluster_info
 
 
@@ -28,6 +29,7 @@ class ElastiCache(PyLibMCCache):
     it used pylibmc in binary mode
     """
     def __init__(self, server, params):
+        self._local = local()
         self.update_params(params)
         super(ElastiCache, self).__init__(server, params)
         if len(self._servers) > 1:

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -108,7 +108,7 @@ def test_no_configuration_protocol_support_with_errors_ignored(Telnet):
         call(b'version\n'),
         call(b'config get cluster\n'),
     ])
-    eq_(info['version'], '1.4.34')
+    eq_(info['version'], b'1.4.34')
     eq_(info['nodes'], ['test:0'])
 
 


### PR DESCRIPTION
In my case that fixed this issue:  `Transport endpoint is not connected`
Might be also related to [this issue](https://github.com/gusdan/django-elasticache/issues/25)
