### PR TITLE
Django v4 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,9 +2,9 @@ Amazon ElastiCache backend for Django
 =====================================
 
 Simple Django cache backend for Amazon ElastiCache (memcached based). It uses
-`pylibmc <http://github.com/lericson/pylibmc>`_ and sets up a connection to each
+`pylibmc <https://github.com/lericson/pylibmc>`_ and sets up a connection to each
 node in the cluster using
-`auto discovery <http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html>`_.
+`auto discovery <https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html>`_.
 
 
 Requirements
@@ -18,11 +18,11 @@ It was written and tested on Python 2.7 and 3.4.
 Installation
 ------------
 
-Get it from `pypi <http://pypi.python.org/pypi/django-elasticache>`_::
+Get it from `pypi <https://pypi.python.org/pypi/django-elasticache>`_::
 
     pip install django-elasticache
 
-or `github <http://github.com/gusdan/django-elasticache>`_::
+or `github <https://github.com/gusdan/django-elasticache>`_::
 
     pip install -e git://github.com/gusdan/django-elasticache.git#egg=django-elasticache
 

--- a/django_elasticache/cluster_utils.py
+++ b/django_elasticache/cluster_utils.py
@@ -2,9 +2,13 @@
 utils for discovery cluster
 """
 from distutils.version import StrictVersion
-from django.utils.encoding import smart_text
 import re
 from telnetlib import Telnet
+
+try:
+    from django.utils.encoding import smart_str
+except ImportError:
+    from django.utils.encoding import smart_text as smart_str
 
 
 class WrongProtocolData(ValueError):
@@ -35,7 +39,7 @@ def get_cluster_info(host, port, ignore_cluster_errors=False):
     if len(version_list) not in [2, 3] or version_list[0] != b'VERSION':
         raise WrongProtocolData('version', res)
     version = version_list[1]
-    if StrictVersion(smart_text(version)) >= StrictVersion('1.4.14'):
+    if StrictVersion(smart_str(version)) >= StrictVersion('1.4.14'):
         cmd = b'config get cluster\n'
     else:
         cmd = b'get AmazonElastiCache:cluster\n'
@@ -50,8 +54,8 @@ def get_cluster_info(host, port, ignore_cluster_errors=False):
         return {
             'version': version,
             'nodes': [
-                '{0}:{1}'.format(smart_text(host),
-                               smart_text(port))
+                '{0}:{1}'.format(smart_str(host),
+                               smart_str(port))
             ]
         }
 
@@ -67,8 +71,8 @@ def get_cluster_info(host, port, ignore_cluster_errors=False):
     try:
         for node in ls[2].split(b' '):
             host, ip, port = node.split(b'|')
-            nodes.append('{0}:{1}'.format(smart_text(ip or host),
-                                        smart_text(port)))
+            nodes.append('{0}:{1}'.format(smart_str(ip or host),
+                                        smart_str(port)))
     except ValueError:
         raise WrongProtocolData(cmd, res)
     return {

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     author='Danil Gusev',
     platforms='any',
     author_email='danil.gusev@gmail.com',
-    url='http://github.com/gusdan/django-elasticache',
+    url='https://github.com/gusdan/django-elasticache',
     license='MIT',
     keywords='elasticache amazon cache pylibmc memcached aws',
     packages=['django_elasticache'],

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -108,7 +108,7 @@ def test_no_configuration_protocol_support_with_errors_ignored(Telnet):
         call(b'version\n'),
         call(b'config get cluster\n'),
     ])
-    eq_(info['version'], '1.4.34')
+    eq_(info['version'], b'1.4.34')
     eq_(info['nodes'], ['test:0'])
 
 


### PR DESCRIPTION
Support for smart_str in Django v4

The `smart_text()` util in Django is deprecated, and has been removed in Django v4, with `smart_str()` its replacement.

This change attempts to import the new `smart_str()` util, falling back to `smart_text()` for earlier versions of Django.